### PR TITLE
Shifted current id header to parent id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.1.2
+-----
+
+* Fixed shifting "current id" header to "parent id". 
+
 0.1.1
 -----
 

--- a/src/Builder/CorrelationIdsRegistryBuilder.php
+++ b/src/Builder/CorrelationIdsRegistryBuilder.php
@@ -56,7 +56,7 @@ class CorrelationIdsRegistryBuilder
         return $this->build(
             $this->extractRequestHeader(
                 $sanitizedRequestHeaders,
-                $this->sanitize($this->provider->provideParentCorrelationIdHeaderName())
+                $this->sanitize($this->provider->provideCurrentCorrelationIdHeaderName())
             ),
             $this->extractRequestHeader(
                 $sanitizedRequestHeaders,


### PR DESCRIPTION
In the current request, the correlation id in the "current id" header comes from the parent request.
It has to be passed as "parent id" to allow the current request to store its actual "current id".

Required in https://github.com/oat-sa/tao-core/pull/2333